### PR TITLE
Bind fields that are contained in a Combination field

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ Changes
 0.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Bind fields that are contained in a ``zc.form.field.Combination`` to fix the
+  ``context`` of those fields.
 
 
 0.4 (2016-01-12)

--- a/src/zc/form/field.py
+++ b/src/zc/form/field.py
@@ -248,11 +248,7 @@ class Union(BaseField):
     def bind(self, object):
         clone = super(Union, self).bind(object)
         # We need to bind the fields too, e.g. for Choice fields
-        clone_fields = []
-        for field in clone.fields:
-            clone_fields.append(field.bind(object))
-        clone_fields = tuple(clone_fields)
-        clone.fields = clone_fields
+        clone.fields = tuple(field.bind(object) for field in clone.fields)
         return clone
 
     def validField(self, value):
@@ -404,11 +400,7 @@ class Combination(BaseField):
     def bind(self, object):
         clone = super(Combination, self).bind(object)
         # We need to bind the fields too, e.g. for Choice fields
-        clone_fields = []
-        for field in clone.fields:
-            clone_fields.append(field.bind(object))
-        clone_fields = tuple(clone_fields)
-        clone.fields = clone_fields
+        clone.fields = tuple(field.bind(object) for field in clone.fields)
         return clone
 
 

--- a/src/zc/form/field.py
+++ b/src/zc/form/field.py
@@ -247,7 +247,7 @@ class Union(BaseField):
 
     def bind(self, object):
         clone = super(Union, self).bind(object)
-        # We need to bind the fields too
+        # We need to bind the fields too, e.g. for Choice fields
         clone_fields = []
         for field in clone.fields:
             clone_fields.append(field.bind(object))
@@ -361,6 +361,17 @@ class Combination(BaseField):
     Traceback (most recent call last):
     ...
     MessageValidationError: (u'${minimum} must be less than or equal to ...
+
+    Binding a Combination field also takes care of binding contained fields:
+
+    >>> context = object()
+    >>> bound_f = f.bind(context)
+    >>> bound_f.context is context
+    True
+    >>> bound_f.fields[0].context is context
+    True
+    >>> bound_f.fields[1].context is context
+    True
     """
 
     interface.implements(interfaces.ICombinationField)
@@ -389,6 +400,17 @@ class Combination(BaseField):
                 f = f.bind(self.context)
                 f.validate(v)
         super(Combination, self)._validate(value)
+
+    def bind(self, object):
+        clone = super(Combination, self).bind(object)
+        # We need to bind the fields too, e.g. for Choice fields
+        clone_fields = []
+        for field in clone.fields:
+            clone_fields.append(field.bind(object))
+        clone_fields = tuple(clone_fields)
+        clone.fields = clone_fields
+        return clone
+
 
 class QueryTextLineConstraint(BaseField, schema.TextLine):
     def __init__(self, index_getter=None, catalog_name=None, index_name=None):


### PR DESCRIPTION
Like the `Union` field and fields based on `zope.schema._field.AbstractCollection` (for example `Tuple`), the `Combination` field needs to bind the contained fields. This is required for fields like Choice with a `BasicContextualSourceFactory`.