### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes
 3.0 (unreleased)
 ----------------
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 Changes
 =======
 
-2.2 (unreleased)
+3.0 (unreleased)
 ----------------
 
 - Drop support for Python 3.8.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os.path
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -23,7 +22,7 @@ TEST_REQUIRES = [
     'zope.configuration',
     'zope.container',
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
     'zope.traversing',
 ]
 
@@ -31,9 +30,6 @@ TEST_REQUIRES = [
 setup(
     name="zc.form",
     version='3.0.dev0',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zc'],
     url='https://github.com/zopefoundation/zc.form',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ TEST_REQUIRES = [
 
 setup(
     name="zc.form",
-    version='2.2.dev0',
+    version='3.0.dev0',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     namespace_packages=['zc'],

--- a/src/zc/__init__.py
+++ b/src/zc/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
